### PR TITLE
Modifies the way that the IV is obtained

### DIFF
--- a/kerberos/src/ma_communication.c
+++ b/kerberos/src/ma_communication.c
@@ -2,196 +2,324 @@
 
 #include <pthread.h>
 #include <curl/curl.h>
+#include <string.h>
 
+#include "protocol/protocol.h"
 #include "logger/logger.h"
 #include "ma_comm_error_codes.h"
 #include "crypto/codes.h"
 
+#define IV_LENGTH 12
+#define MUTUAL_AUTH_HEADER_LENGTH 80
+
 typedef struct SCommContext {
-	uint8_t isSecureChannelEnabled;
-	uint8_t initCurl;
-	void* pKerberosContext;
+    uint8_t isSecureChannelEnabled;
+    uint8_t initCurl;
+    void* pKerberosContext;
+    char mutualAuthHeader[MUTUAL_AUTH_HEADER_LENGTH];
 } CommContext;
 
 static int initialized = 0;
 static CommContext internalContext;
 
+uint8_t concatIvWithCipheredData(uint8_t *iv,
+                                 size_t ivLength,
+                                 uint8_t *cipherData,
+                                 size_t cipherDataLength,
+                                 uint8_t **concatData,
+                                 size_t *concatDataLength);
+
+uint8_t rebuildMutualAuthenticationHeader();
+
 void initCommContext(CommContext *pContext) {
-	pContext->isSecureChannelEnabled = 0;
-	pContext->initCurl = 0;
-	pContext->pKerberosContext = NULL;
+    pContext->isSecureChannelEnabled = 0;
+    pContext->initCurl = 0;
+    pContext->pKerberosContext = NULL;
+    memset(pContext->mutualAuthHeader, 0, MUTUAL_AUTH_HEADER_LENGTH);
 }
 
 uint8_t ma_communication_init(uint8_t initCurl,
-							  uint8_t enableLogger,
-							  uint8_t enableSecureChannel,
-							  const char* urlRequestAS,
-							  const char* urlRequestAP,
-							  const uint8_t *appId,
-							  size_t appIdSize,
-							  const uint8_t *serverId,
-							  size_t serverIdSize,
-							  const uint8_t *sharedKey,
-							  size_t sharedKeySize) {
-	int8_t result = 0;
+                              uint8_t enableLogger,
+                              uint8_t enableSecureChannel,
+                              const char* urlRequestAS,
+                              const char* urlRequestAP,
+                              const uint8_t *appId,
+                              size_t appIdSize,
+                              const uint8_t *serverId,
+                              size_t serverIdSize,
+                              const uint8_t *sharedKey,
+                              size_t sharedKeySize) {
+    int8_t result = 0;
 
-	if ( (!urlRequestAS) || (!urlRequestAS) ) {
-		return MA_COMM_INVALID_PARAMETER;
-	}
+    if ( (!urlRequestAS) || (!urlRequestAS) ) {
+        return MA_COMM_INVALID_PARAMETER;
+    }
 
-	if (enableLogger) {
-		logger_enable();
-	}
+    if (enableLogger) {
+        logger_enable();
+    }
 
-	if (initialized) {
-		LOG("You cannot call init twice\n");
-		return MA_COMM_INVALID_STATE;
-	}
+    if (initialized) {
+        LOG("You cannot call init twice\n");
+        return MA_COMM_INVALID_STATE;
+    }
 
-	initCommContext(&internalContext);
+    initCommContext(&internalContext);
 
-	internalContext.initCurl = initCurl;
-	internalContext.isSecureChannelEnabled = enableSecureChannel;
-	result = kerberos_protocol_init(urlRequestAS,
-								    urlRequestAP,
-									appId,
-									appIdSize,
-									serverId,
-									serverIdSize,
-									sharedKey,
-									sharedKeySize,
-								    &internalContext.pKerberosContext);
-	if (result != 0) {
-		LOG("Error to initialize kerberos context\n");
-		return MA_COMM_INVALID_STATE;
-	}
+    internalContext.initCurl = initCurl;
+    internalContext.isSecureChannelEnabled = enableSecureChannel;
+    result = kerberos_protocol_init(urlRequestAS,
+                                    urlRequestAP,
+                                    appId,
+                                    appIdSize,
+                                    serverId,
+                                    serverIdSize,
+                                    sharedKey,
+                                    sharedKeySize,
+                                    &internalContext.pKerberosContext);
+    if (result != 0) {
+        LOG("Error to initialize kerberos context\n");
+        return MA_COMM_INVALID_STATE;
+    }
 
-	if (internalContext.initCurl) {
-		curl_global_init(CURL_GLOBAL_ALL);
-	}
+    if (internalContext.initCurl) {
+        curl_global_init(CURL_GLOBAL_ALL);
+    }
 
-	initialized = 1;
-	LOG("MA comm initialized\n");
+    initialized = 1;
+    LOG("MA comm initialized\n");
     return MA_COMM_SUCCESS;
 }
 
 uint8_t ma_communication_deinit() {
-	if (!initialized) {
-		LOG("MA communication is not initialized\n");
-		return MA_COMM_INVALID_STATE;
-	}
+    if (!initialized) {
+        LOG("MA communication is not initialized\n");
+        return MA_COMM_INVALID_STATE;
+    }
 
-	if (internalContext.initCurl) {
-		curl_global_cleanup();
-	}
+    if (internalContext.initCurl) {
+        curl_global_cleanup();
+    }
 
-	kerberos_protocol_deinit(&internalContext.pKerberosContext);
+    kerberos_protocol_deinit(&internalContext.pKerberosContext);
+    memset(internalContext.mutualAuthHeader, 0, MUTUAL_AUTH_HEADER_LENGTH);
 
-	LOG("MA comm deinitialized\n");
-	return MA_COMM_SUCCESS;
+    LOG("MA comm deinitialized\n");
+    return MA_COMM_SUCCESS;
 }
 
 uint8_t ma_communication_send(const char *url,
-							  const char** headers,
-							  const size_t numHeaders,
-							  unsigned char* content,
-							  size_t contentSize,
-							  unsigned char** pResponse,
-							  size_t *responseSize) {
+                              char * httpMethod,
+                              struct curl_slist **headers,
+                              unsigned char* content,
+                              size_t contentSize,
+                              uint32_t *httpStatusCode,
+                              unsigned char** pResponse,
+                              size_t *responseSize) {
 
-	int32_t result = 0;
-	uint8_t* pContentToSend = content;
-	size_t contentToSendSize = contentSize;
-	if ((!url) || (!content) || (!responseSize) ) {
-		LOG("Invalid parameter\n");
-		return MA_COMM_INVALID_PARAMETER;
-	}
+    int32_t result = 0;
+    uint8_t* pContentToSend = content;
+    size_t contentToSendSize = contentSize;
+    *httpStatusCode = 0;
+    if ((!url) || (!content) || (!responseSize) ) {
+        if (*headers) {
+            curl_slist_free_all(*headers);
+            *headers = NULL;
+        }
+        LOG("Invalid parameter\n");
+        return MA_COMM_INVALID_PARAMETER;
+    }
 
-	if (!initialized) {
-		LOG("MA communication is not initialized\n");
-		return MA_COMM_INVALID_STATE;
-	}
+    if (!initialized) {
+        if (*headers) {
+            curl_slist_free_all(*headers);
+            *headers = NULL;
+        }
+        LOG("MA communication is not initialized\n");
+        return MA_COMM_INVALID_STATE;
+    }
 
-	if (!kerberos_protocol_is_mutual_authenticated(internalContext.pKerberosContext)) {
-		LOG("The application is not mutual authenticated\n");
-		result = kerberos_protocol_execute_handshake(internalContext.pKerberosContext);
-		if (result != MA_COMM_SUCCESS) {
-			LOG("Fail to execute kerberos handshake. Error %d\n", result);
-			return MA_COMM_INVALID_STATE;
-		}
-	} else {
-		LOG("The application is mutual authenticated\n");
-	}
+    if (!kerberos_protocol_is_mutual_authenticated(internalContext.pKerberosContext)) {
+        LOG("The application is not mutual authenticated\n");
+        result = kerberos_protocol_execute_handshake(internalContext.pKerberosContext);
+        if (result != MA_COMM_SUCCESS) {
+            if (*headers) {
+                curl_slist_free_all(*headers);
+                *headers = NULL;
+            }
+            LOG("Fail to execute kerberos handshake. Error %d\n", result);
+            return MA_COMM_INVALID_STATE;
+        }
+        rebuildMutualAuthenticationHeader();
+    } else {
+        LOG("The application is mutual authenticated\n");
+    }
 
-	if (internalContext.isSecureChannelEnabled) {
-		LOG("Ciphering the content\n");
-		uint8_t *cipherContent = NULL;
-		size_t cipherContentSize = 0;
-		//encrypt
-		result = encryptTo(NULL,
-						   0,
-						   content,
-						   contentSize,
-						   &cipherContent,
-						   &cipherContentSize);
-		if (result != SUCCESSFULL_OPERATION) {
-			LOG("Fail to encrypt content\n");
-			return MA_COMM_INVALID_STATE;
-		}
-		pContentToSend = cipherContent;
-		contentToSendSize = cipherContentSize;
-	}
+    if ( (internalContext.isSecureChannelEnabled) && (contentSize > 0) ){
+        LOG("Ciphering the content\n");
+        uint8_t *cipherContent = NULL;
+        size_t cipherContentSize = 0;
 
-	uint8_t* pResponseAux = NULL;
-	size_t responseSizeAux = 0;
+        //todo change this call to a secure random generator
+        uint8_t iv[IV_LENGTH];
+        generateRandom(iv, IV_LENGTH);
 
-	LOG("Sending the message\n");
+        //encrypt
+        result = changeIvAndEncryptTo(iv,
+                                      IV_LENGTH,
+                                      NULL,
+                                      0,
+                                      content,
+                                      contentSize,
+                                      &cipherContent,
+                                      &cipherContentSize);
+        if (result != SUCCESSFULL_OPERATION) {
+            if (*headers) {
+                curl_slist_free_all(*headers);
+                *headers = NULL;
+            }
+            LOG("Fail to encrypt content\n");
+            return MA_COMM_INVALID_STATE;
+        }
 
-	result = send_message(url,
-						  headers,
-						  numHeaders,
-						  pContentToSend,
-						  contentSize,
-						  &pResponseAux,
-						  &responseSizeAux);
-	if (internalContext.isSecureChannelEnabled) {
-		free(pContentToSend);
-	}
-	if (result != SUCCESSFULL_OPERATION) {
-		LOG("Fail to send message\n");
-		return MA_COMM_INVALID_STATE;
-	}
+        // concatenate iv with the ciphered data
+        result = concatIvWithCipheredData(iv,
+                                          IV_LENGTH,
+                                          cipherContent,
+                                          cipherContentSize,
+                                          &pContentToSend,
+                                          &contentToSendSize);
+        free(cipherContent);
+        if (result != MA_COMM_SUCCESS) {
+            if (*headers) {
+                curl_slist_free_all(*headers);
+                *headers = NULL;
+            }
+            LOG("Fail to allocate memory\n");
+            return MA_COMM_OUT_OF_MEMORY;
+        }
+    }
 
-	LOG("response size: %d\n", responseSizeAux);
-	size_t i = 0;
-	LOG("--- begin response ---\n");
-	for (i = 0; i < responseSizeAux; ++i) {
-		LOG("%c", pResponse[i]);
-	}
-	LOG("\n--- End response ---\n");
+    // set the headers
+    *headers = curl_slist_append(*headers, internalContext.mutualAuthHeader);
 
-	if ( (internalContext.isSecureChannelEnabled) && (responseSizeAux > 0) ) {
-		LOG("Deciphering the response\n");
-		uint8_t *plainContent = NULL;
-		size_t plainContentSize = 0;
-		// decrypt
-		result = decryptTo(NULL,
-						   0,
-						   pResponseAux,
-						   responseSizeAux,
-						   &plainContent,
-						   &plainContentSize);
-		free(pResponseAux);
-		if (result != SUCCESSFULL_OPERATION) {
-			LOG("Fail to decrypt response\n");
-			return MA_COMM_INVALID_STATE;
-		}
-		pResponseAux = plainContent;
-		responseSizeAux = plainContentSize;
-	}
+    // send the message
+    uint8_t* pResponseAux = NULL;
+    size_t responseSizeAux = 0;
 
-	*pResponse = pResponseAux;
-	*responseSize = responseSizeAux;
+    result = send_message(url,
+                          httpMethod,
+                          headers,
+                          pContentToSend,
+                          contentToSendSize,
+                          httpStatusCode,
+                          &pResponseAux,
+                          &responseSizeAux);
+    if (internalContext.isSecureChannelEnabled) {
+        free(pContentToSend);
+    }
 
-	return MA_COMM_SUCCESS;
+    if (result != SUCCESSFULL_OPERATION) {
+        LOG("Fail to send message\n");
+        return MA_COMM_INVALID_STATE;
+    }
+
+    if ( (internalContext.isSecureChannelEnabled) && (responseSizeAux > 0) ) {
+        LOG("Deciphering the response\n");
+        uint8_t *plainContent = NULL;
+        size_t plainContentSize = 0;
+
+        // retrieve the iv
+        size_t offset = 0;
+        uint8_t ivLength = pResponseAux[0];
+        offset += 1;
+        uint8_t* iv = NULL;
+        iv = (uint8_t*) malloc(ivLength);
+        if (!iv) {
+            free(pResponseAux);
+            LOG("Fail to allocate memory\n");
+            return MA_COMM_OUT_OF_MEMORY;
+        }
+
+        memcpy(iv, &pResponseAux[offset], ivLength);
+        offset += ivLength;
+
+        // decrypt
+        result = changeIvAndDecryptTo(iv,
+                                      ivLength,
+                                      NULL,
+                                      0,
+                                      &pResponseAux[offset],
+                                      responseSizeAux - offset,
+                                      &plainContent,
+                                      &plainContentSize);
+        free(iv);
+        free(pResponseAux);
+        if (result != SUCCESSFULL_OPERATION) {
+            LOG("Fail to decrypt response\n");
+            return MA_COMM_INVALID_STATE;
+        }
+        pResponseAux = plainContent;
+        responseSizeAux = plainContentSize;
+    }
+
+    *pResponse = pResponseAux;
+    *responseSize = responseSizeAux;
+
+    return MA_COMM_SUCCESS;
+}
+
+uint8_t concatIvWithCipheredData(uint8_t *iv,
+                                 size_t ivLength,
+                                 uint8_t *cipherData,
+                                 size_t cipherDataLength,
+                                 uint8_t **concatData,
+                                 size_t *concatDataLength) {
+
+    size_t finalContentSize = cipherDataLength + ivLength + 1;
+    size_t offset = 0;
+
+    if (ivLength > 255) {
+        return MA_COMM_INVALID_PARAMETER;
+    }
+
+    uint8_t* finalContent = malloc(finalContentSize);
+    if (!finalContent) {
+        return MA_COMM_OUT_OF_MEMORY;
+    }
+
+    finalContent[0] = ivLength;
+    offset += 1;
+    memcpy(&finalContent[offset], iv, ivLength);
+    offset += IV_LENGTH;
+    memcpy(&finalContent[offset], cipherData, cipherDataLength);
+    offset += cipherDataLength;
+
+    *concatData = finalContent;
+    *concatDataLength = finalContentSize;
+    return MA_COMM_SUCCESS;
+}
+
+uint8_t rebuildMutualAuthenticationHeader() {
+
+    uint8_t sessionId[SESSION_ID_LENGTH];
+    memset(internalContext.mutualAuthHeader, 0, MUTUAL_AUTH_HEADER_LENGTH);
+
+    kerberos_protocol_get_session_id(internalContext.pKerberosContext,
+                                     SESSION_ID_LENGTH,
+                                     sessionId);
+    uint32_t j = 0;
+    uint32_t i = 0;
+    //todo do the error checking
+    j = snprintf(internalContext.mutualAuthHeader,
+                 MUTUAL_AUTH_HEADER_LENGTH,
+                 "ma-session-id: ");
+    for (i = 0; i < SESSION_ID_LENGTH; ++i, j+=2) {
+        snprintf(&internalContext.mutualAuthHeader[j],
+                 MUTUAL_AUTH_HEADER_LENGTH,
+                 "%02x",
+                 sessionId[i]);
+    }
+
+    return MA_COMM_SUCCESS;
 }

--- a/kerberos/src/ma_communication.h
+++ b/kerberos/src/ma_communication.h
@@ -9,16 +9,23 @@
 
 #include <stdint.h>
 #include <stdlib.h>
+#include <curl/curl.h>
+
+//HTTP methods
+#define    HTTP_METHOD_DELETE "DELETE"
+#define    HTTP_METHOD_PUT "PUT"
+#define    HTTP_METHOD_GET "GET"
+#define    HTTP_METHOD_POST "POST"
 
 /**
  * @brief Initializes the library and configures it. It must be called
  * before any call to ma_communication_send function.
  * @param[in] initCurl indicates if the library should initialize the libcurl
- * 			  and take care about it. (0 to false, non-zero otherwise)
+ *               and take care about it. (0 to false, non-zero otherwise)
  * @param[in] enableLogger indicates if the library should log in default output.
- * 			  (0 to false, non-zero otherwise)
+ *               (0 to false, non-zero otherwise)
  * @param[in] enableSecureChannel indicates if the library should use the secure
- * 			  channel to encrypt/decrypt messages. (0 to false, non-zero otherwise)
+ *               channel to encrypt/decrypt messages. (0 to false, non-zero otherwise)
  * @param[in] urlRequestAS a C string that represents the URL to call the requestAS
  * @param[in] urlRequestAP a C string that represents the URL to call the requestAP
  * @param[in] appId a vector with the current application id
@@ -32,16 +39,16 @@
  * sensitive information
  */
 uint8_t ma_communication_init(uint8_t initCurl,
-							  uint8_t enableLogger,
-							  uint8_t enableSecureChannel,
-						  	  const char* urlRequestAS,
-							  const char* urlRequestAP,
-							  const uint8_t *appId,
-							  size_t appIdSize,
-							  const uint8_t *serverId,
-							  size_t serverIdSize,
-							  const uint8_t *sharedKey,
-							  size_t sharedKeySize);
+                              uint8_t enableLogger,
+                              uint8_t enableSecureChannel,
+                                const char* urlRequestAS,
+                              const char* urlRequestAP,
+                              const uint8_t *appId,
+                              size_t appIdSize,
+                              const uint8_t *serverId,
+                              size_t serverIdSize,
+                              const uint8_t *sharedKey,
+                              size_t sharedKeySize);
 
 /**
  * @brief Deinitializes the library. It's wise to call it on your shutdown flow
@@ -55,24 +62,26 @@ uint8_t ma_communication_deinit();
  * the kerberos handshake is done, if not, it makes the handshake. It also
  * encrypts the request and decrypts the result.
  * @param[in] url the URL target to send the message
- * @param[in] headers a vector with headers (NULL is acceptable)
- * @param[in] numHeaders how many headers there are in the 'headers' vector
+ * @param[in] httpMethod the HTTP desirable, you can use the HTTP_METHOD_ defines
+ * @param[in] headers a pointer to a libcurl header structure
  * @param[in] content the message's content
  * @param[in] contentSize the message context's size
+ * @param[out] httpStatusCode the HTTP status code
  * @param[out] response the response to your message
  * @param[out] responseSize the responses's size
  * @return 0 on success, otherwise non-zero
  * @warning: it is user responsibility to clean the 'content' pointer, the
  * library does not make it.
- * @attention: the following header is added automatically in the user's request
- * 'Content-Type: application/x-www-form-urlencoded'
+ * @warning: the library take control of the header pointer, you do not
+ * need to take care of it anymore.
  */
 uint8_t ma_communication_send(const char *url,
-						  	  const char** headers,
-							  const size_t numHeaders,
-							  unsigned char* content,
-							  size_t contentSize,
-							  unsigned char** response,
-							  size_t *responseSize);
+                              char * httpMethod,
+                              struct curl_slist **headers,
+                              unsigned char* content,
+                              size_t contentSize,
+                              uint32_t *httpStatusCode,
+                              unsigned char** pResponse,
+                              size_t *responseSize);
 
 #endif /* KERBEROS_SRC_MA_COMMUNICATION_H_ */

--- a/kerberos/src/protocol/communication.c
+++ b/kerberos/src/protocol/communication.c
@@ -1,7 +1,6 @@
 #include "communication.h"
 
 #include <stdlib.h>
-#include <curl/curl.h>
 
 #include "logger/logger.h"
 #include "ma_comm_error_codes.h"
@@ -39,17 +38,17 @@ size_t process_chuck(void *pContent, size_t size, size_t nmemb, void *pUserPtr) 
  * Upon receipt of a reply, the callback method specified in loader.addEventListener is called
  */
 uint8_t send_message(const char* url,
-                     const char** headers,
-                     const size_t numHeaders,
+                     const char *method,
+                     struct curl_slist **headers,
                      uint8_t* encodedInput,
                      size_t encodedLength,
+                     uint32_t* httpStatusCode,
                      uint8_t** pResponse,
                      size_t* pResponseSize) {
     CURLcode res;
     BufferStruct buffer;
     uint8_t result = 0;
     CURL *pCurlHandler = NULL;
-    struct curl_slist *pSlist = NULL;
 
     // initialize output parameters
     *pResponseSize = 0;
@@ -68,18 +67,20 @@ uint8_t send_message(const char* url,
         goto FAIL;
     }
 
+    // set the http method
+    curl_easy_setopt(pCurlHandler, CURLOPT_CUSTOMREQUEST, method);
+
     // set the headers
-    pSlist = curl_slist_append(pSlist, "Content-Type: application/x-www-form-urlencoded");
-    size_t i = 0;
-    for(i = 0; i < numHeaders; ++i) {
-        pSlist = curl_slist_append(pSlist, headers[i]);
+    if (*headers) {
+        curl_easy_setopt(pCurlHandler, CURLOPT_HTTPHEADER, *headers);
     }
 
     // prepare the request
-    curl_easy_setopt(pCurlHandler, CURLOPT_HTTPHEADER, pSlist);
     curl_easy_setopt(pCurlHandler, CURLOPT_URL, url);
-    curl_easy_setopt(pCurlHandler, CURLOPT_POSTFIELDSIZE, encodedLength);
-    curl_easy_setopt(pCurlHandler, CURLOPT_POSTFIELDS, encodedInput);
+    if (encodedLength > 0) {
+        curl_easy_setopt(pCurlHandler, CURLOPT_POSTFIELDSIZE, encodedLength);
+        curl_easy_setopt(pCurlHandler, CURLOPT_POSTFIELDS, encodedInput);
+    }
     curl_easy_setopt(pCurlHandler, CURLOPT_WRITEFUNCTION, process_chuck);
     curl_easy_setopt(pCurlHandler, CURLOPT_WRITEDATA, (void *)&buffer);
 
@@ -88,6 +89,8 @@ uint8_t send_message(const char* url,
         LOG("send message failed: %s\n", curl_easy_strerror(res));
         goto FAIL;
     } else {
+        curl_easy_getinfo (pCurlHandler, CURLINFO_RESPONSE_CODE, httpStatusCode);
+        LOG("http status code: %u\n", *httpStatusCode);
         *pResponseSize = buffer.size;
         *pResponse = buffer.pData;
         goto SUCCESS;
@@ -107,8 +110,9 @@ CLEAN_UP:
     if (pCurlHandler) {
         curl_easy_cleanup(pCurlHandler);
     }
-    if (pSlist) {
-        curl_slist_free_all(pSlist);
+    if (*headers) {
+        curl_slist_free_all(*headers);
+        *headers = NULL;
     }
 
     return result;

--- a/kerberos/src/protocol/communication.h
+++ b/kerberos/src/protocol/communication.h
@@ -3,12 +3,14 @@
 
 #include <stdint.h>
 #include <string.h>
+#include <curl/curl.h>
 
 uint8_t send_message(const char* url,
-                     const char** headers,
-                     const size_t numHeaders,
+                     const char *method,
+                     struct curl_slist **headers,
                      uint8_t* encodedInput,
                      size_t encodedLength,
+                     uint32_t* httpStatusCode,
                      uint8_t** pResponse,
                      size_t* pResponseSize);
 

--- a/kerberos/src/protocol/protocol.h
+++ b/kerberos/src/protocol/protocol.h
@@ -26,5 +26,9 @@ uint8_t kerberos_protocol_execute_handshake(void* pContext);
 
 uint8_t kerberos_protocol_is_mutual_authenticated(void* pContext);
 
+uint8_t kerberos_protocol_get_session_id(void* pContext,
+                                         size_t sessionIdSize,
+                                         uint8_t* sessionId);
+
 
 #endif /* KERBEROS_PROTOCOL_ */

--- a/libaes/src/CryptoAPI.c
+++ b/libaes/src/CryptoAPI.c
@@ -16,145 +16,145 @@ uint8_t ivLength = 0;
 uint8_t tagLength = 0;
 
 errno_t initSecureChannel(uint8_t kLength,
-						  uint8_t iLength,
-						  uint8_t tLen,
-						  uint8_t* kLocal,
-						  uint8_t* kExtern,
-						  uint8_t* iLocal,
-						  uint8_t* iExtern) {
-	errno_t result;
-	
-	if(!kLocal || !kExtern || !iLocal || !iExtern) {
-		return INVALID_PARAMETER;
-	}
-	
-	/* Clear previous values */
-	result = clearSecureChannel();
-	if(result != SUCCESSFULL_OPERATION) {
-		return INVALID_STATE;
-	}
-	
-	tagLength = tLen;
-	
-	keyLength = kLength;
-	keyLocal = (uint8_t*) malloc(sizeof(uint8_t) * keyLength);
-	keyExtern = (uint8_t*) malloc(sizeof(uint8_t) * keyLength);
-	
-	ivLength = iLength;
-	ivLocal = (uint8_t*) malloc(sizeof(uint8_t) * ivLength);
-	ivExtern = (uint8_t*) malloc(sizeof(uint8_t) * ivLength);
+                          uint8_t iLength,
+                          uint8_t tLen,
+                          uint8_t* kLocal,
+                          uint8_t* kExtern,
+                          uint8_t* iLocal,
+                          uint8_t* iExtern) {
+    errno_t result;
 
-	if ( (!keyLocal) || (!keyExtern) || (!ivLocal) || (!ivExtern) ) {
-		clearSecureChannel();
-		return INVALID_STATE;
-	}
-	
-	memcpy(keyLocal, kLocal, sizeof(uint8_t) * keyLength);	
-	memcpy(keyExtern, kExtern, sizeof(uint8_t) * keyLength);
-	memcpy(ivLocal, iLocal, sizeof(uint8_t) * ivLength);
-	memcpy(ivExtern, iExtern, sizeof(uint8_t) * ivLength);
+    if(!kLocal || !kExtern || !iLocal || !iExtern) {
+        return INVALID_PARAMETER;
+    }
 
-	return SUCCESSFULL_OPERATION;
+    /* Clear previous values */
+    result = clearSecureChannel();
+    if(result != SUCCESSFULL_OPERATION) {
+        return INVALID_STATE;
+    }
+
+    tagLength = tLen;
+
+    keyLength = kLength;
+    keyLocal = (uint8_t*) malloc(sizeof(uint8_t) * keyLength);
+    keyExtern = (uint8_t*) malloc(sizeof(uint8_t) * keyLength);
+
+    ivLength = iLength;
+    ivLocal = (uint8_t*) malloc(sizeof(uint8_t) * ivLength);
+    ivExtern = (uint8_t*) malloc(sizeof(uint8_t) * ivLength);
+
+    if ( (!keyLocal) || (!keyExtern) || (!ivLocal) || (!ivExtern) ) {
+        clearSecureChannel();
+        return INVALID_STATE;
+    }
+
+    memcpy(keyLocal, kLocal, sizeof(uint8_t) * keyLength);
+    memcpy(keyExtern, kExtern, sizeof(uint8_t) * keyLength);
+    memcpy(ivLocal, iLocal, sizeof(uint8_t) * ivLength);
+    memcpy(ivExtern, iExtern, sizeof(uint8_t) * ivLength);
+
+    return SUCCESSFULL_OPERATION;
 }
 
 errno_t clearSecureChannel() {
-	
-	if(keyLocal) {
-		memset_s(keyLocal, keyLength, 0, keyLength);
-		free(keyLocal);
-		keyLocal = NULL;
-	}
-	if(keyExtern) {
-		memset_s(keyExtern, keyLength, 0, keyLength);
-		free(keyExtern);
-		keyExtern = NULL;
-	}
-	if(ivLocal) {
-		memset_s(ivLocal, ivLength, 0, ivLength);
-		free(ivLocal);
-		ivLocal = NULL;
-	}
-	if(ivExtern) {
-		memset_s(ivExtern, ivLength, 0, ivLength);
-		free(ivExtern);
-		ivExtern = NULL;
-	}
-	
-	return SUCCESSFULL_OPERATION;
+
+    if(keyLocal) {
+        memset_s(keyLocal, keyLength, 0, keyLength);
+        free(keyLocal);
+        keyLocal = NULL;
+    }
+    if(keyExtern) {
+        memset_s(keyExtern, keyLength, 0, keyLength);
+        free(keyExtern);
+        keyExtern = NULL;
+    }
+    if(ivLocal) {
+        memset_s(ivLocal, ivLength, 0, ivLength);
+        free(ivLocal);
+        ivLocal = NULL;
+    }
+    if(ivExtern) {
+        memset_s(ivExtern, ivLength, 0, ivLength);
+        free(ivExtern);
+        ivExtern = NULL;
+    }
+
+    return SUCCESSFULL_OPERATION;
 }
 
 errno_t initChannel()
 {
-	errno_t result;
-	
-	result = initWriteChannel();
-	if(result != SUCCESSFULL_OPERATION) {
-		goto FAIL;
-	}
-	
-	result = initReadChannel();
-	if(result != SUCCESSFULL_OPERATION) {
-		goto FAIL;
-	}
-	result |= aesClearContext(&aesLocal);
-	result |= gcmClearContext(&writeChannel);
-	result |= aesClearContext(&aesExtern);
-	result |= gcmClearContext(&readChannel);
+    errno_t result;
+
+    result = initWriteChannel();
+    if(result != SUCCESSFULL_OPERATION) {
+        goto FAIL;
+    }
+
+    result = initReadChannel();
+    if(result != SUCCESSFULL_OPERATION) {
+        goto FAIL;
+    }
+    result |= aesClearContext(&aesLocal);
+    result |= gcmClearContext(&writeChannel);
+    result |= aesClearContext(&aesExtern);
+    result |= gcmClearContext(&readChannel);
 FAIL:
-	return result;
+    return result;
 }
 
 /* Initializes client to server communication */
 errno_t initWriteChannel() 
 {
-	errno_t result;
-	
-	result = aesInit(keyLocal, keyLength, DIR_ENCRYPTION, &aesLocal);
-	if(result != SUCCESSFULL_OPERATION) {
-		goto FAIL;
-	}
-	
-	result = gcmInit(&writeChannel, 16, DIR_ENCRYPTION, ivLocal, ivLength, tagLength, &aesLocal, aesProcessBlock);
-	if(result != SUCCESSFULL_OPERATION) {
-		goto FAIL;
-	}
-	
-	result = SUCCESSFULL_OPERATION;
-	goto SUCCESS;
+    errno_t result;
+
+    result = aesInit(keyLocal, keyLength, DIR_ENCRYPTION, &aesLocal);
+    if(result != SUCCESSFULL_OPERATION) {
+        goto FAIL;
+    }
+
+    result = gcmInit(&writeChannel, 16, DIR_ENCRYPTION, ivLocal, ivLength, tagLength, &aesLocal, aesProcessBlock);
+    if(result != SUCCESSFULL_OPERATION) {
+        goto FAIL;
+    }
+
+    result = SUCCESSFULL_OPERATION;
+    goto SUCCESS;
 FAIL:
-	result |= aesClearContext(&aesLocal);
-	result |= gcmClearContext(&writeChannel);
+    result |= aesClearContext(&aesLocal);
+    result |= gcmClearContext(&writeChannel);
 SUCCESS:
-	return result;
+    return result;
 }
 
 /* Initializes server to client communication */
 errno_t initReadChannel() 
 {
-	errno_t result;
-	
-	/* Only using DIR_ENCRYPTION because of gcm mode */
-	result = aesInit(keyExtern, keyLength, DIR_ENCRYPTION, &aesExtern);	
-	if(result != SUCCESSFULL_OPERATION) {
-		goto FAIL;
-	}
-	
-	result = gcmInit(&readChannel, 16, DIR_DECRYPTION, ivExtern, ivLength, tagLength, &aesExtern, aesProcessBlock);
-	if(result != SUCCESSFULL_OPERATION) {
-		goto FAIL;
-	}
-	result = SUCCESSFULL_OPERATION;
-	goto SUCCESS;
+    errno_t result;
+
+    /* Only using DIR_ENCRYPTION because of gcm mode */
+    result = aesInit(keyExtern, keyLength, DIR_ENCRYPTION, &aesExtern);
+    if(result != SUCCESSFULL_OPERATION) {
+        goto FAIL;
+    }
+
+    result = gcmInit(&readChannel, 16, DIR_DECRYPTION, ivExtern, ivLength, tagLength, &aesExtern, aesProcessBlock);
+    if(result != SUCCESSFULL_OPERATION) {
+        goto FAIL;
+    }
+    result = SUCCESSFULL_OPERATION;
+    goto SUCCESS;
 FAIL:
-	result |= aesClearContext(&aesExtern);
-	result |= gcmClearContext(&readChannel);
+    result |= aesClearContext(&aesExtern);
+    result |= gcmClearContext(&readChannel);
 SUCCESS:
-	return result;
+    return result;
 }
 
 errno_t encryptToJS(uint8_t* aad, uint32_t aadLength, uint8_t* plaintext, uint32_t plaintextLength, uint8_t* ciphertext)
 {
-	errno_t result;
+    errno_t result;
         int i;
         uint8_t* output;
         uint32_t outputLength, outputOffset = 0;
@@ -194,7 +194,7 @@ errno_t encryptToJS(uint8_t* aad, uint32_t aadLength, uint8_t* plaintext, uint32
         if(result != SUCCESSFULL_OPERATION) {
                 goto FAIL_FREE;
         }
-		memcpy(ciphertext, output, outputOffset);
+        memcpy(ciphertext, output, outputOffset);
         inc(ivLocal, ivLength);
         result = SUCCESSFULL_OPERATION;
         goto SUCCESS;
@@ -210,173 +210,220 @@ SUCCESS:
         return result;
 }
 
+errno_t changeIvAndEncryptTo(uint8_t* newLocalIv,
+                             uint8_t newLocalIvLength,
+                             uint8_t* aad,
+                             uint32_t aadLength,
+                             uint8_t* plaintext,
+                             uint32_t plaintextLength,
+                             uint8_t** ciphertext,
+                             size_t* ciphertextLength) {
+    if (ivLength == newLocalIvLength) {
+        memcpy(ivLocal, newLocalIv, newLocalIvLength);
+    } else {
+        //todo implement this case
+        return INVALID_PARAMETER;
+    }
+
+    return encryptTo(aad,
+                         aadLength,
+                     plaintext,
+                     plaintextLength,
+                     ciphertext,
+                     ciphertextLength);
+}
+
+
 errno_t encryptTo(uint8_t* aad, uint32_t aadLength, uint8_t* plaintext, uint32_t plaintextLength, uint8_t** ciphertext, size_t* ciphertextLength)
 {
-	errno_t result;
-	int i;
-	uint8_t* output;
-	uint32_t outputLength, outputOffset = 0;
-	
-	if(ciphertext == NULL || ciphertextLength == NULL) {
-		result = INVALID_PARAMETER;
-		goto FAIL;
-	}
-	result = initWriteChannel();
-	if(result != SUCCESSFULL_OPERATION) {
-		goto FAIL;
-	}
-	
-	/* Estimates the maximum size of the ciphertext considering the tag */
-	result = gcmCalculateOutputSize(&writeChannel, plaintextLength, &outputLength);
-	output = (uint8_t*) malloc(sizeof(uint8_t) * outputLength);
-	if(output == NULL && outputLength != 0) {
-		result = INVALID_STATE;
-		goto FAIL;
-	}
-	
-	/* Authenticates the AAD */
-	if(aadLength > 0) {
-		result = gcmUpdateAAD(&writeChannel, aad, aadLength, 0);
-		if(result != SUCCESSFULL_OPERATION) {
-			goto FAIL_FREE;
-		}
-	}
-	
-	/* Encrypts the plaintext and appends the tag */
-	result = gcmFinal(&writeChannel, plaintext, plaintextLength, 0, output, outputLength, &outputOffset);
-	if(result != SUCCESSFULL_OPERATION) {
-		goto FAIL_FREE;
-	}
-	
-	result = resize_s(&output, outputLength, outputOffset);
-	if(result != SUCCESSFULL_OPERATION) {
-		goto FAIL_FREE;
-	}
-	
-	*ciphertext = output;
-	*ciphertextLength = outputOffset;
-	inc(ivLocal, ivLength);
-	result = SUCCESSFULL_OPERATION;
-	goto SUCCESS;
-	
+    errno_t result;
+    int i;
+    uint8_t* output;
+    uint32_t outputLength, outputOffset = 0;
+
+    if(ciphertext == NULL || ciphertextLength == NULL) {
+        result = INVALID_PARAMETER;
+        goto FAIL;
+    }
+    result = initWriteChannel();
+    if(result != SUCCESSFULL_OPERATION) {
+        goto FAIL;
+    }
+
+    /* Estimates the maximum size of the ciphertext considering the tag */
+    result = gcmCalculateOutputSize(&writeChannel, plaintextLength, &outputLength);
+    output = (uint8_t*) malloc(sizeof(uint8_t) * outputLength);
+    if(output == NULL && outputLength != 0) {
+        result = INVALID_STATE;
+        goto FAIL;
+    }
+
+    /* Authenticates the AAD */
+    if(aadLength > 0) {
+        result = gcmUpdateAAD(&writeChannel, aad, aadLength, 0);
+        if(result != SUCCESSFULL_OPERATION) {
+            goto FAIL_FREE;
+        }
+    }
+
+    /* Encrypts the plaintext and appends the tag */
+    result = gcmFinal(&writeChannel, plaintext, plaintextLength, 0, output, outputLength, &outputOffset);
+    if(result != SUCCESSFULL_OPERATION) {
+        goto FAIL_FREE;
+    }
+
+    result = resize_s(&output, outputLength, outputOffset);
+    if(result != SUCCESSFULL_OPERATION) {
+        goto FAIL_FREE;
+    }
+
+    *ciphertext = output;
+    *ciphertextLength = outputOffset;
+
+    result = SUCCESSFULL_OPERATION;
+    goto SUCCESS;
+
 FAIL_FREE:
-	result |= memset_s(output, outputOffset, 0, outputOffset);
-	free(output);
-	
+    result |= memset_s(output, outputOffset, 0, outputOffset);
+    free(output);
+
 FAIL:
 SUCCESS:
-	result |= memset_s(plaintext, plaintextLength, 0, plaintextLength);
-	result |= memset_s(aad, aadLength, 0, aadLength);
-	return result;
+    result |= memset_s(plaintext, plaintextLength, 0, plaintextLength);
+    result |= memset_s(aad, aadLength, 0, aadLength);
+    return result;
 }
-	
+
+errno_t changeIvAndDecryptTo(uint8_t* newExternalIv,
+                             uint8_t newExternalIvLength,
+                             uint8_t* aad,
+                             uint32_t aadLength,
+                             uint8_t* ciphertext,
+                             uint32_t ciphertextLength,
+                             uint8_t** plaintext,
+                             size_t* plaintextLength) {
+    if (ivLength == newExternalIvLength) {
+        memcpy(ivExtern, newExternalIv, newExternalIvLength);
+    } else {
+        //todo implement this case
+        return INVALID_PARAMETER;
+    }
+
+    return decryptTo(aad,
+                         aadLength,
+                     ciphertext,
+                     ciphertextLength,
+                     plaintext,
+                     plaintextLength);
+}
+
 errno_t decryptTo(uint8_t* aad, uint32_t aadLength, uint8_t* ciphertext, uint32_t ciphertextLength, uint8_t** plaintext, size_t* plaintextLength)
 {
-	uint8_t *output;
-	uint32_t outputLength, outputOffset = 0;
-	errno_t result;
+    uint8_t *output;
+    uint32_t outputLength, outputOffset = 0;
+    errno_t result;
 
-	result = initReadChannel();
-	if(result != SUCCESSFULL_OPERATION) {
-		goto FAIL;
-	}
-	
-	/* Estimates the maximum size of the ciphertext considering the tag */
-	result = gcmCalculateOutputSize(&readChannel, ciphertextLength, &outputLength);
-	
-	output = (uint8_t*) malloc(sizeof(uint8_t) * outputLength);
-	if(output == NULL && outputLength != 0) {
-		result = INVALID_STATE;
-		goto FAIL;
-	}
-	
-	/* Authenticates the AAD */
-	if(aad != NULL && aadLength > 0) {
-		result = gcmUpdateAAD(&readChannel, aad, aadLength, 0);
-		if(result != SUCCESSFULL_OPERATION) {
-			goto FAIL_FREE;
-		}
-	}
-	
-	/* Decrypts the ciphertext and removes the tag */
-	result = gcmFinal(&readChannel, ciphertext, ciphertextLength, 0, output, outputLength, &outputOffset);
-	if(result != SUCCESSFULL_OPERATION) {
-		goto FAIL_FREE;
-	}
-	
-	result = resize_s(&output, outputLength, outputOffset);
-	if(result != SUCCESSFULL_OPERATION) {
-		goto FAIL_FREE;
-	}
-	
-	*plaintext = output;
-	*plaintextLength = outputOffset;
-	/* Initializes the server to client channel */
-	//inc(ivExtern, ivLength);
-	goto SUCCESS;
+    result = initReadChannel();
+    if(result != SUCCESSFULL_OPERATION) {
+        goto FAIL;
+    }
+
+    /* Estimates the maximum size of the ciphertext considering the tag */
+    result = gcmCalculateOutputSize(&readChannel, ciphertextLength, &outputLength);
+
+    output = (uint8_t*) malloc(sizeof(uint8_t) * outputLength);
+    if(output == NULL && outputLength != 0) {
+        result = INVALID_STATE;
+        goto FAIL;
+    }
+
+    /* Authenticates the AAD */
+    if(aad != NULL && aadLength > 0) {
+        result = gcmUpdateAAD(&readChannel, aad, aadLength, 0);
+        if(result != SUCCESSFULL_OPERATION) {
+            goto FAIL_FREE;
+        }
+    }
+
+    /* Decrypts the ciphertext and removes the tag */
+    result = gcmFinal(&readChannel, ciphertext, ciphertextLength, 0, output, outputLength, &outputOffset);
+    if(result != SUCCESSFULL_OPERATION) {
+        goto FAIL_FREE;
+    }
+
+    result = resize_s(&output, outputLength, outputOffset);
+    if(result != SUCCESSFULL_OPERATION) {
+        goto FAIL_FREE;
+    }
+
+    *plaintext = output;
+    *plaintextLength = outputOffset;
+    /* Initializes the server to client channel */
+    //inc(ivExtern, ivLength);
+    goto SUCCESS;
 
 FAIL_FREE:
-	result |= memset_s(output, outputOffset, 0, outputOffset);
-	free(output);
+    result |= memset_s(output, outputOffset, 0, outputOffset);
+    free(output);
 
 FAIL:
 SUCCESS:
-	result |= memset_s(ciphertext, ciphertextLength, 0, ciphertextLength);
-	result |= memset_s(aad, aadLength, 0, aadLength);
-	return result;
+    result |= memset_s(ciphertext, ciphertextLength, 0, ciphertextLength);
+    result |= memset_s(aad, aadLength, 0, aadLength);
+    return result;
 }
 
 errno_t decryptToJS(uint8_t* aad, uint32_t aadLength, uint8_t* ciphertext, uint32_t ciphertextLength, uint8_t* plaintext)
 {
-	uint8_t *output;
-	uint32_t outputLength, outputOffset = 0;
-	errno_t result;
+    uint8_t *output;
+    uint32_t outputLength, outputOffset = 0;
+    errno_t result;
 
-	result = initReadChannel();
-	if(result != SUCCESSFULL_OPERATION) {
-		goto FAIL;
-	}
-	
-	/* Estimates the maximum size of the ciphertext considering the tag */
-	result = gcmCalculateOutputSize(&readChannel, ciphertextLength, &outputLength);
-	
-	output = (uint8_t*) malloc(sizeof(uint8_t) * outputLength);
-	if(output == NULL && outputLength != 0) {
-		result = INVALID_STATE;
-		goto FAIL;
-	}
-	
-	/* Authenticates the AAD */
-	if(aad != NULL && aadLength > 0) {
-		result = gcmUpdateAAD(&readChannel, aad, aadLength, 0);
-		if(result != SUCCESSFULL_OPERATION) {
-			goto FAIL_FREE;
-		}
-	}
-	
-	/* Decrypts the ciphertext and removes the tag */
-	result = gcmFinal(&readChannel, ciphertext, ciphertextLength, 0, output, outputLength, &outputOffset);
-	if(result != SUCCESSFULL_OPERATION) {
-		goto FAIL_FREE;
-	}
-	
-	result = resize_s(&output, outputLength, outputOffset);
-	if(result != SUCCESSFULL_OPERATION) {
-		goto FAIL_FREE;
-	}
+    result = initReadChannel();
+    if(result != SUCCESSFULL_OPERATION) {
+        goto FAIL;
+    }
 
-	memcpy(plaintext, output, outputOffset);	
-	/* Initializes the server to client channel */
-	//inc(ivExtern, ivLength);
-	goto SUCCESS;
+    /* Estimates the maximum size of the ciphertext considering the tag */
+    result = gcmCalculateOutputSize(&readChannel, ciphertextLength, &outputLength);
+
+    output = (uint8_t*) malloc(sizeof(uint8_t) * outputLength);
+    if(output == NULL && outputLength != 0) {
+        result = INVALID_STATE;
+        goto FAIL;
+    }
+
+    /* Authenticates the AAD */
+    if(aad != NULL && aadLength > 0) {
+        result = gcmUpdateAAD(&readChannel, aad, aadLength, 0);
+        if(result != SUCCESSFULL_OPERATION) {
+            goto FAIL_FREE;
+        }
+    }
+
+    /* Decrypts the ciphertext and removes the tag */
+    result = gcmFinal(&readChannel, ciphertext, ciphertextLength, 0, output, outputLength, &outputOffset);
+    if(result != SUCCESSFULL_OPERATION) {
+        goto FAIL_FREE;
+    }
+
+    result = resize_s(&output, outputLength, outputOffset);
+    if(result != SUCCESSFULL_OPERATION) {
+        goto FAIL_FREE;
+    }
+
+    memcpy(plaintext, output, outputOffset);
+    /* Initializes the server to client channel */
+    //inc(ivExtern, ivLength);
+    goto SUCCESS;
 
 FAIL_FREE:
-	result |= memset_s(output, outputOffset, 0, outputOffset);
-	free(output);
+    result |= memset_s(output, outputOffset, 0, outputOffset);
+    free(output);
 
 FAIL:
 SUCCESS:
-	result |= memset_s(ciphertext, ciphertextLength, 0, ciphertextLength);
-	result |= memset_s(aad, aadLength, 0, aadLength);
-	return result;
+    result |= memset_s(ciphertext, ciphertextLength, 0, ciphertextLength);
+    result |= memset_s(aad, aadLength, 0, aadLength);
+    return result;
 }

--- a/libaes/src/CryptoAPI.h
+++ b/libaes/src/CryptoAPI.h
@@ -7,15 +7,57 @@
 #include "util/cryptoutil.h"
 #include "symmetric/aes.h"
 
-/* Using the biggest length possible for the tag */
+// Using the biggest length possible for the tag
 #define TAG_LEN 128
 
 errno_t initReadChannel();
 errno_t initWriteChannel();
-errno_t initSecureChannel(uint8_t /* keyLength */, uint8_t /* ivLength */, uint8_t /* tagLen */, uint8_t* /* kLocal */, uint8_t* /* kExtern */, uint8_t* /* iLocal */, uint8_t* /* iExtern */);
-errno_t encryptTo(uint8_t* /* aad */, uint32_t /* aadLength */, uint8_t* /* plaintext */, uint32_t /* plaintextLength */, uint8_t** /* ciphertext */, size_t* /* ciphertextLength */);
-errno_t decryptTo(uint8_t* /* aad */, uint32_t /* aadLength */, uint8_t* /* ciphertext */, uint32_t /* ciphertextLength */, uint8_t** /* plaintext */, size_t* /* plaintextLength */);
+errno_t initSecureChannel(uint8_t keyLength,
+                          uint8_t ivLength,
+                          uint8_t tagLen,
+                          uint8_t* kLocal,
+                          uint8_t* kExtern,
+                          uint8_t* iLocal,
+                          uint8_t* iExtern);
 errno_t clearSecureChannel();
-errno_t encryptToJS(uint8_t* /* aad */, uint32_t /* aadLength */, uint8_t* /* plaintext */, uint32_t /* plaintextLength */, uint8_t* /* ciphertext */);
-errno_t decryptToJS(uint8_t* /* aad */, uint32_t /* aadLength */, uint8_t* /* ciphertext */, uint32_t /* ciphertextLength */, uint8_t* /* plaintext */);
-#endif /* CRYPTO_ */
+
+errno_t encryptTo(uint8_t* aad,
+                  uint32_t aadLength,
+                  uint8_t* plaintext,
+                  uint32_t plaintextLength,
+                  uint8_t** ciphertext,
+                  size_t* ciphertextLength );
+errno_t changeIvAndEncryptTo(uint8_t* ivExternal,
+                             uint8_t ivExternalLength,
+                             uint8_t* aad,
+                             uint32_t aadLength,
+                             uint8_t* plaintext,
+                             uint32_t plaintextLength,
+                             uint8_t** ciphertext,
+                             size_t* ciphertextLength);
+errno_t encryptToJS(uint8_t* aad,
+                    uint32_t aadLength,
+                    uint8_t* plaintext,
+                    uint32_t plaintextLength,
+                    uint8_t* ciphertext);
+
+errno_t decryptTo(uint8_t* aad,
+                 uint32_t aadLength,
+                 uint8_t* ciphertext,
+                 uint32_t ciphertextLength,
+                 uint8_t** plaintext,
+                 size_t* plaintextLength);
+errno_t changeIvAndDecryptTo(uint8_t* ivInternal,
+                             uint8_t ivInternalLength,
+                             uint8_t* aad,
+                             uint32_t aadLength,
+                             uint8_t* ciphertext,
+                             uint32_t ciphertextLength,
+                             uint8_t** plaintext,
+                             size_t* plaintextLength);
+errno_t decryptToJS(uint8_t* aad,
+                    uint32_t aadLength,
+                    uint8_t* ciphertext,
+                    uint32_t ciphertextLength,
+                    uint8_t* plaintext);
+#endif //CRYPTO_


### PR DESCRIPTION
- Modifies libaes's interface to add the possibility to change the IV;
- Changes the public interface to use the libcurl 's header structure;
- Changes the send_message method to add the HTTP method and the HTTP status code;
- Appends the headers to add the mutual authentication header;
- Adds to IV to the encrypted message. Now the message has the following schema:
IV length + length + encrypted data + tag